### PR TITLE
fix: crash on collectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sern/handler",
-  "version": "1.1.5-beta",
+  "version": "1.1.6-beta",
   "description": "A customizable, batteries-included, powerful discord.js framework to automate and streamline bot development.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/handler/events/interactionHandler.ts
+++ b/src/handler/events/interactionHandler.ts
@@ -89,7 +89,7 @@ export default class InteractionHandler extends EventsHandler<{
 
     protected setState(state: { event: Interaction; mod: CommandModule | undefined }): void {
         if (state.mod === undefined) {
-            this.payloadSubject.error(SernError.UndefinedModule);
+            this.wrapper?.sernEmitter?.emit('error', SernError.UndefinedModule);
         } else {
             //if statement above checks already, safe cast
             this.payloadSubject.next(state as { event: Interaction; mod: CommandModule });


### PR DESCRIPTION
In other words, sern would crash on undefined modules. Collected interactions go through the same event listener as the one listening to commands. Sern crashed on these interactions which is unintended behavior

Does not crash now, only warns.