### PR TITLE
fix(autocomplete): now support multiple autocomplete options

### DIFF
--- a/src/handler/utilities/treeSearch.ts
+++ b/src/handler/utilities/treeSearch.ts
@@ -1,12 +1,14 @@
-import type { SernOptionsData } from '../structures/module';
+import type { SernAutocompleteData, SernOptionsData } from '../structures/module';
 import { ApplicationCommandOptionType, AutocompleteInteraction } from 'discord.js';
 
 export default function treeSearch(
     iAutocomplete: AutocompleteInteraction,
     options: SernOptionsData[] | undefined,
-) {
+): SernAutocompleteData {
     if (options === undefined) return undefined;
     const _options = options.slice(); // required to prevent direct mutation of options
+    let autocompleteData: SernAutocompleteData;
+
     while (_options.length > 0) {
         const cur = _options.pop()!;
         switch (cur.type) {
@@ -29,12 +31,12 @@ export default function treeSearch(
                     if (cur.autocomplete) {
                         const choice = iAutocomplete.options.getFocused(true);
                         if (cur.name === choice.name && cur.autocomplete) {
-                            return cur;
+                            autocompleteData = cur;
                         }
-                        return undefined;
                     }
                 }
                 break;
         }
     }
+    return autocompleteData;
 }


### PR DESCRIPTION
- Hopefully fixes [this](https://canary.discord.com/channels/889026545715400705/987796629627228221/1026322262208557107)
- Tested by myself 😎 
<details>
<summary> Sample Code Used </summary>

```ts
import { commandModule, CommandType } from "@sern/handler";
import { ApplicationCommandOptionType } from "discord.js";
import { publish } from "#plugins";

export default commandModule({
	type: CommandType.Slash,
	plugins: [publish()],
	options: [
		{
			name: "ac1",
			description: "autocomplete 1",
			type: ApplicationCommandOptionType.String,
			autocomplete: true,
			command: {
				onEvent: [],
				execute(ctx) {
					const ac1 = ["foo", "bar"];
					return ctx.respond(ac1.map((c) => ({ name: c, value: c })));
				},
			},
		},
		{
			name: "ac2",
			description: "autocomplete 2",
			type: ApplicationCommandOptionType.String,
			autocomplete: true,
			command: {
				onEvent: [],
				execute(ctx) {
					const ac2 = ["hello", "world", "Evo"];
					return ctx.respond(ac2.map((c) => ({ name: c, value: c })));
				},
			},
		},
	],
	execute(ctx, args) {
		const s = ctx.interaction.options.getString("ac1");
		const s2 = ctx.interaction.options.getString("ac2");
		return ctx.reply(`You chose ${s} and ${s2}`);
	},
});
```
</details>