### PR TITLE
chore: upgrade ts-results-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "iti": "^0.6.0",
         "rxjs": "^7.8.0",
-        "ts-results-es": "latest"
+        "ts-results-es": "^4.0.0"
     },
     "devDependencies": {
         "@faker-js/faker": "^8.0.1",

--- a/src/core/ioc/dependency-injection.ts
+++ b/src/core/ioc/dependency-injection.ts
@@ -66,12 +66,7 @@ export async function composeRoot(
     }
     //Build the container based on the callback provided by the user
     conf.build(container as CoreContainer<Omit<CoreDependencies, '@sern/client'>>);
-    try {
-        container.get('@sern/client');
-    } catch {
-        throw new Error(SernError.MissingRequired + ' No client was provided');
-    }
-
+    
     if (!hasLogger) {
         container.get('@sern/logger')?.info({ message: 'All dependencies loaded successfully.' });
     }

--- a/src/core/operators.ts
+++ b/src/core/operators.ts
@@ -52,7 +52,7 @@ export const arrayifySource = map(src => (Array.isArray(src) ? (src as unknown[]
  * Checks if the stream of results is all ok.
  */
 export const everyPluginOk: OperatorFunction<VoidResult, boolean> = pipe(
-    every(result => result.ok),
+    every(result => result.isOk()),
     defaultIfEmpty(true),
 );
 
@@ -74,10 +74,10 @@ export function handleError<C>(crashHandler: ErrorHandling, logging?: Logging) {
 export const filterTap = <K, R>(onErr: (e: R) => void): OperatorFunction<Result<K, R>, K> => 
     pipe(
         concatMap(result => {
-            if(result.ok) {
-                return of(result.val)
+            if(result.isOk()) {
+                return of(result.value)
             }
-            onErr(result.val);
+            onErr(result.error);
             return EMPTY
 
         })

--- a/src/core/structures/context.ts
+++ b/src/core/structures/context.ts
@@ -31,15 +31,21 @@ export class Context extends CoreContext<Message, ChatInputCommandInteraction> {
     }
 
     public get id(): Snowflake {
-        return this.ctx.val.id;
+        return safeUnwrap(this.ctx
+                            .map(m => m.id)
+                            .mapErr(i => i.id));
     }
 
     public get channel() {
-        return this.ctx.val.channel;
+        return safeUnwrap(this.ctx
+                            .map(m => m.channel)
+                            .mapErr(i => i.channel));
     }
 
     public get channelId(): Snowflake {
-        return safeUnwrap(this.ctx.map(m => m.channelId).mapErr(i => i.channelId));
+        return safeUnwrap(this.ctx
+                            .map(m => m.channelId)
+                            .mapErr(i => i.channelId));
     }
     
     /**
@@ -47,7 +53,9 @@ export class Context extends CoreContext<Message, ChatInputCommandInteraction> {
      * else, interaction.user
      */
     public get user(): User {
-        return safeUnwrap(this.ctx.map(m => m.author).mapErr(i => i.user));
+        return safeUnwrap(this.ctx
+                            .map(m => m.author)
+                            .mapErr(i => i.user));
     }
 
     public get userId(): Snowflake {
@@ -55,29 +63,41 @@ export class Context extends CoreContext<Message, ChatInputCommandInteraction> {
     }
 
     public get createdTimestamp(): number {
-        return this.ctx.val.createdTimestamp;
+        return safeUnwrap(this.ctx 
+                            .map(m => m.createdTimestamp)
+                            .mapErr(i => i.createdTimestamp));
     }
 
     public get guild() {
-        return this.ctx.val.guild;
+        return safeUnwrap(this.ctx
+                            .map(m => m.guild)
+                            .mapErr(i => i.guild));
     }
 
     public get guildId() {
-        return this.ctx.val.guildId;
+        return safeUnwrap(this.ctx
+                            .map(m => m.guildId)
+                            .mapErr(i => i.guildId));
     }
     /*
      * interactions can return APIGuildMember if the guild it is emitted from is not cached
      */
     public get member() {
-        return this.ctx.val.member;
+        return safeUnwrap(this.ctx
+                            .map(m => m.member)
+                            .mapErr(i => i.member));
     }
 
     public get client(): Client {
-        return this.ctx.val.client;
+        return safeUnwrap(this.ctx
+                            .map(m => m.client)
+                            .mapErr(i => i.client));
     }
 
     public get inGuild(): boolean {
-        return this.ctx.val.inGuild();
+        return safeUnwrap(this.ctx
+                            .map(m => m.inGuild())
+                            .mapErr(i => i.inGuild()));
     }
 
     public async reply(content: ReplyOptions) {
@@ -100,5 +120,5 @@ export class Context extends CoreContext<Message, ChatInputCommandInteraction> {
 }
 
 function safeUnwrap<T>(res: Result<T, T>) {
-    return res.val;
+    return res.unwrap()
 }

--- a/src/core/structures/core-context.ts
+++ b/src/core/structures/core-context.ts
@@ -7,7 +7,7 @@ import * as assert from 'node:assert';
  */
 export abstract class CoreContext<M, I> {
     protected constructor(protected ctx: Either<M, I>) {
-        assert.ok(typeof ctx.val === 'object' && ctx.val != null);
+        assert.ok(typeof ctx === 'object' && ctx != null);
     }
     get message(): M {
         return this.ctx.expect(SernError.MismatchEvent);
@@ -17,7 +17,7 @@ export abstract class CoreContext<M, I> {
     }
 
     public isMessage(): this is CoreContext<M, never> {
-        return this.ctx.ok;
+        return this.ctx.isOk();
     }
 
     public isSlash(): this is CoreContext<never, I> {

--- a/src/handlers/event-utils.ts
+++ b/src/handlers/event-utils.ts
@@ -150,11 +150,11 @@ export function executeModule(
         //converting the task into a promise so rxjs can resolve the Awaitable properly
         concatMap(() => Result.wrapAsync(async () => task())),
         concatMap(result => {
-            if (result.ok) {
+            if (result.isOk()) {
                 emitter.emit('module.activate', SernEmitter.success(module));
                 return EMPTY;
             } else {
-                return throwError(() => SernEmitter.failure(module, result.val));
+                return throwError(() => SernEmitter.failure(module, result.error));
             }
         }),
     );
@@ -182,7 +182,7 @@ export function createResultResolver<
         const task$ = config.createStream(args);
         return task$.pipe(
             tap(result => {
-                result.err && config.onStop?.(args.module);
+                result.isErr() && config.onStop?.(args.module);
             }),
             everyPluginOk,
             filterMapTo(() => config.onNext(args)),

--- a/test/core/module-loading.test.ts
+++ b/test/core/module-loading.test.ts
@@ -8,7 +8,6 @@ describe('module-loading', () => {
         const filename = Files.fmtFileName(name+'.'+extension);
         expect(filename).toBe(name)
     })
-
     
 //    todo: handle commands with multiple extensions
 //    it('should properly extract filename from file, nested multiple', () => {

--- a/test/handlers/id.test.ts
+++ b/test/handlers/id.test.ts
@@ -18,7 +18,7 @@ function createRandomCommandModules() {
         CommandType.Button,
     ];
     return commandModule({
-        type: randomCommandType[Math.floor(Math.random() * randomCommandType.length)],
+        type: faker.helpers.uniqueArray(randomCommandType, 1)[0],
         description: faker.string.alpha(),
         name: faker.string.alpha(),
         execute: () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -619,7 +619,7 @@ __metadata:
     iti: ^0.6.0
     prettier: 2.8.8
     rxjs: ^7.8.0
-    ts-results-es: latest
+    ts-results-es: ^4.0.0
     tsup: ^6.7.0
     typescript: 5.0.2
     vitest: latest
@@ -3844,10 +3844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-results-es@npm:latest":
-  version: 3.6.1
-  resolution: "ts-results-es@npm:3.6.1"
-  checksum: af0d93ee4d3bd9e99a5fd4ac4b0ad090aef0a61e1f38ee596cfebe8d47090b34a2557d3778e00b4aae7c74962133805275ffffe56716e4d747fa559a926d9ced
+"ts-results-es@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "ts-results-es@npm:4.0.0"
+  checksum: 32a7059491e36d06c5a1084fe9be8021a0beb2d94a94b0c3fa85dc3e96561bf34fb8fd60ebe661064c9fc2bafcf437b6b65f119e8d7497af7f76cda9d9a2a945
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
chore
- upgrade ts-results-es to 4.0.0
- update context and corresponding things to it (adjusted to ts-results-es new API)
- removed check for @sern/client 