### PR TITLE
deprecate: mode

### DIFF
--- a/src/core/module-loading.ts
+++ b/src/core/module-loading.ts
@@ -33,6 +33,7 @@ export async function importModule<T>(absPath: string) {
         .wrap(() => module.getInstance())
         .unwrapOr(module) as T;
 }
+
 export async function defaultModuleLoader<T extends Module>(absPath: string): ModuleResult<T> {
     let module = await importModule<T>(absPath);
     assert(module, `Found an undefined module: ${absPath}`);
@@ -53,7 +54,7 @@ export function buildModuleStream<T extends Module>(
     return from(input).pipe(mergeMap(defaultModuleLoader<T>));
 }
 
-export const getFullPathTree = (dir: string, mode: boolean) => readPaths(resolve(dir), mode);
+export const getFullPathTree = (dir: string) => readPaths(resolve(dir));
 
 export const filename = (path: string) => fmtFileName(basename(path));
 
@@ -70,22 +71,18 @@ async function deriveFileInfo(dir: string, file: string) {
         base: basename(file),
     };
 }
-async function* readPaths(dir: string, shouldDebug: boolean): AsyncGenerator<string> {
+async function* readPaths(dir: string): AsyncGenerator<string> {
     try {
         const files = await readdir(dir);
         for (const file of files) {
             const { fullPath, fileStats, base } = await deriveFileInfo(dir, file);
             if (fileStats.isDirectory()) {
                 //Todo: refactor so that i dont repeat myself for files (line 71)
-                if (isSkippable(base)) {
-                    if (shouldDebug) console.info(`ignored directory: ${fullPath}`);
-                } else {
-                    yield* readPaths(fullPath, shouldDebug);
+                if (!isSkippable(base)) {
+                    yield* readPaths(fullPath);
                 }
             } else {
-                if (isSkippable(base)) {
-                    if (shouldDebug) console.info(`ignored: ${fullPath}`);
-                } else {
+                if (!isSkippable(base)) {
                     yield 'file:///' + fullPath;
                 }
             }
@@ -98,38 +95,30 @@ async function* readPaths(dir: string, shouldDebug: boolean): AsyncGenerator<str
 const requir = createRequire(import.meta.url);
 
 export function loadConfig(wrapper: Wrapper | 'file'): Wrapper {
-    if (wrapper === 'file') {
-        console.log('Experimental loading of sern.config.json');
-        const config = requir(resolve('sern.config.json')) as {
-            language: string;
-            defaultPrefix?: string;
-            mode?: 'PROD' | 'DEV';
-            paths: {
-                base: string;
-                commands: string;
-                events?: string;
-            };
-        };
-        const makePath = (dir: keyof typeof config.paths) =>
-            config.language === 'typescript'
-                ? join('dist', config.paths[dir]!)
-                : join(config.paths[dir]!);
-
-        console.log('Loading config: ', config);
-        const commandsPath = makePath('commands');
-
-        console.log('Commands path is set to', commandsPath);
-        let eventsPath: string | undefined;
-        if (config.paths.events) {
-            eventsPath = makePath('events');
-            console.log('Events path is set to', eventsPath);
-        }
-        return {
-            defaultPrefix: config.defaultPrefix,
-            commands: commandsPath,
-            events: eventsPath,
-            mode: config.mode,
-        };
+    if (wrapper !== 'file') {
+        return wrapper;
     }
-    return wrapper;
+    console.log('Experimental loading of sern.config.json');
+    const config = requir(resolve('sern.config.json')); 
+
+    const makePath = (dir: PropertyKey) =>
+        config.language === 'typescript'
+            ? join('dist', config.paths[dir]!)
+            : join(config.paths[dir]!);
+ 
+    console.log('Loading config: ', config);
+    const commandsPath = makePath('commands');
+ 
+    console.log('Commands path is set to', commandsPath);
+    let eventsPath: string | undefined;
+    if (config.paths.events) {
+        eventsPath = makePath('events');
+        console.log('Events path is set to', eventsPath);
+    }
+    return {
+        defaultPrefix: config.defaultPrefix,
+        commands: commandsPath,
+        events: eventsPath,
+    };
+    
 }

--- a/src/sern.ts
+++ b/src/sern.ts
@@ -27,13 +27,12 @@ export function init(maybeWrapper: Wrapper | 'file') {
     const dependencies = useDependencies();
     const logger = dependencies[2],
         errorHandler = dependencies[1];
-    const mode = isDevMode(wrapper.mode ?? process.env.MODE);
 
     if (wrapper.events !== undefined) {
-        eventsHandler(dependencies, Files.getFullPathTree(wrapper.events, mode));
+        eventsHandler(dependencies, Files.getFullPathTree(wrapper.events));
     }
     //Ready event: load all modules and when finished, time should be taken and logged
-    startReadyEvent(dependencies, Files.getFullPathTree(wrapper.commands, mode)).add(() => {
+    startReadyEvent(dependencies, Files.getFullPathTree(wrapper.commands)).add(() => {
         const time = ((performance.now() - startTime) / 1000).toFixed(2);
         dependencies[0].emit('modulesLoaded');
         logger?.info({
@@ -45,14 +44,6 @@ export function init(maybeWrapper: Wrapper | 'file') {
     const interactions$ = interactionHandler(dependencies);
     // listening to the message stream and interaction stream
     merge(messages$, interactions$).pipe(handleCrash(errorHandler, logger)).subscribe();
-}
-
-function isDevMode(mode: string | undefined) {
-    console.info(`Detected mode: "${mode}"`);
-    if (mode === undefined) {
-        console.info('No mode found in process.env, assuming DEV');
-    }
-    return mode === 'DEV' || mode == undefined;
 }
 
 function useDependencies() {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -9,7 +9,8 @@ export interface Wrapper {
     defaultPrefix?: string;
     events?: string;
     /**
-     * @deprecated
+     * Overload to enable mode in case developer does not use a .env file.
+     * @deprecated - https://github.com/sern-handler/handler/pull/325
      */
     mode?: string
     /*

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -9,9 +9,9 @@ export interface Wrapper {
     defaultPrefix?: string;
     events?: string;
     /**
-     * Overload to enable mode in case developer does not use a .env file.
+     * @deprecated
      */
-    mode?: 'DEV' | 'PROD';
+    mode?: string
     /*
      * @deprecated
      */

--- a/test/core/context.test.ts
+++ b/test/core/context.test.ts
@@ -1,0 +1,85 @@
+import { describe, vi, it, expect } from'vitest'
+import { Context } from '../../src';
+import { faker } from '@faker-js/faker'
+describe('Context', () => {
+    // Mocked message and interaction objects for testing
+    const mockMessage = {
+        id: 'messageId',
+        channel: 'channelId',
+        channelId: 'channelId',
+        interaction: { 
+            id: faker.string.uuid()
+        },
+        author: { id: 'userId' },
+        createdTimestamp: 1234567890,
+        guild: 'guildId',
+        guildId: 'guildId',
+        member: { id: 'memberId' },
+        client: { id: 'clientId' },
+        inGuild: vi.fn().mockReturnValue(true),
+        reply: vi.fn(),
+    };
+
+    const mockInteraction = {
+        id: 'interactionId',
+        user: { id: 'userId' },
+        channel: 'channelId',
+        channelId: 'channelId',
+        createdTimestamp: 1234567890,
+        guild: 'guildId',
+        guildId: 'guildId',
+        fetchReply: vi.fn().mockResolvedValue({}),
+        member: { id: 'memberId' },
+        client: { id: 'clientId' },
+        isChatInputCommand: vi.fn().mockResolvedValue(true),
+        inGuild: vi.fn().mockReturnValue(true),
+        reply: vi.fn().mockResolvedValue({}),
+    };
+
+    it('should create a context from a message', () => {
+        //@ts-ignore
+        const context = Context.wrap(mockMessage);
+        expect(context).toBeDefined();
+        expect(context.id).toBe('messageId');
+    });
+    it('should throw error if accessing interaction as message', () => {
+        //@ts-ignore
+        const context = Context.wrap(mockMessage);
+        expect(context).toBeDefined();
+        expect(() => context.interaction)
+            .toThrowError('You cannot use message when an interaction fired or vice versa');
+
+    })
+     it('should throw error if accessing message as interaction', () => {
+        //@ts-ignore
+        const context = Context.wrap(mockInteraction);
+        expect(context).toBeDefined();
+        expect(() => context.message)
+            .toThrowError('You cannot use message when an interaction fired or vice versa');
+
+    })
+
+    it('should create a context from an interaction', () => {
+        //@ts-ignore
+        const context = Context.wrap(mockInteraction);
+        expect(context).toBeDefined();
+        expect(context.id).toBe('interactionId'); 
+    });
+
+    it('should reply to a context with a message', async () => {
+        //@ts-ignore
+        const context = Context.wrap(mockMessage);
+        const replyOptions = { content: 'Hello, world!' };
+        await context.reply(replyOptions);
+        expect(mockMessage.reply).toHaveBeenCalledWith(replyOptions);
+    });
+
+    it('should reply to a context with an interaction', async () => {
+        //@ts-ignore
+        const context = Context.wrap(mockInteraction);
+        const replyOptions = { content: 'Hello, world!' };
+        await context.reply(replyOptions);
+        expect(mockInteraction.reply).toHaveBeenCalledWith(replyOptions);
+    });
+
+});


### PR DESCRIPTION
# Deciding to remove experimental mode for sern/handler npm package
- the handler package shouldn't have this type of logic. This should be up to the CLI build tool or user.
- For random debug statements, i'll probably use esbuild's drop label functionality
- It tightly couples logic to data and it isn't the best solution.  