### PR TITLE
feat: presence

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "author": "SernDevs",
     "license": "MIT",
     "dependencies": {
+        "callsites": "^3.1.0",
         "iti": "^0.6.0",
         "rxjs": "^7.8.0",
         "ts-results-es": "^4.0.0"

--- a/src/core/module-loading.ts
+++ b/src/core/module-loading.ts
@@ -6,9 +6,19 @@ import assert from 'assert';
 import { createRequire } from 'node:module';
 import type { ImportPayload, Wrapper } from '../types/core';
 import type { Module } from '../types/core-modules';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'node:url';
+
+export const shouldHandle = (path: string, fpath: string) => {
+    const newPath = new URL(fpath+extname(path), path).href;
+    return {
+        exists: existsSync(fileURLToPath(newPath)),
+        path: newPath
+    }
+}
+
 
 export type ModuleResult<T> = Promise<ImportPayload<T>>;
-
 /**
  * Import any module based on the absolute path.
  * This can accept four types of exported modules
@@ -66,6 +76,7 @@ const isSkippable = (filename: string) => {
     const validExtensions = ['.js', '.cjs', '.mts', '.mjs', '.cts', '.ts', ''];
     return filename[0] === '!' || !validExtensions.includes(extname(filename));
 };
+
 async function deriveFileInfo(dir: string, file: string) {
     const fullPath = join(dir, file);
     return {
@@ -74,6 +85,7 @@ async function deriveFileInfo(dir: string, file: string) {
         base: basename(file),
     };
 }
+
 async function* readPaths(dir: string): AsyncGenerator<string> {
     try {
         const files = await readdir(dir);
@@ -118,6 +130,8 @@ export function loadConfig(wrapper: Wrapper | 'file'): Wrapper {
         eventsPath = makePath('events');
         console.log('Events path is set to', eventsPath);
     }
+    
+
     return {
         defaultPrefix: config.defaultPrefix,
         commands: commandsPath,

--- a/src/core/modules.ts
+++ b/src/core/modules.ts
@@ -61,18 +61,19 @@ export function discordEvent<T extends keyof ClientEvents>(mod: {
     });
 }
 
+
+/**
+ * @deprecated
+ */
 function prepareClassPlugins(c: Module) {
     const [onEvent, initPlugins] = partitionPlugins(c.plugins);
     c.plugins = initPlugins as InitPlugin[];
     c.onEvent = onEvent as ControlPlugin[];
 }
-//
-// Class modules:
-// Can be refactored.
-// Both implement singleton, could I make them inherit a singleton parent class?
+
 /**
- * @Experimental
- * Will be refactored / changed in future
+ * @deprecated
+ * Will be removed in future
  */
 export abstract class CommandExecutable<const Type extends CommandType = CommandType> {
     abstract type: Type;
@@ -92,8 +93,8 @@ export abstract class CommandExecutable<const Type extends CommandType = Command
 }
 
 /**
- * @Experimental
- * Will be refactored in future
+ * @deprecated
+ * Will be removed in future
  */
 export abstract class EventExecutable<Type extends EventType> {
     abstract type: Type;

--- a/src/core/presences.ts
+++ b/src/core/presences.ts
@@ -4,11 +4,13 @@ import type { Emitter } from "./contracts/emitter";
 
 type Status = 'online' | 'idle' | 'invisible' | 'dnd'
 
-interface Once { 
+export interface Result { 
     status?: Status;
     afk?: boolean;
     activities?: ActivitiesOptions[];
     shardId?: number[];
+    repeat?: number | [Emitter, string];
+    onRepeat?: (previous: Result) => Result; 
 }
 
 export type Config <T extends (keyof Dependencies)[]> = 
@@ -17,17 +19,52 @@ export type Config <T extends (keyof Dependencies)[]> =
     execute: (...v: IntoDependencies<T>) => Result;
 };
 
-export function create<T extends (keyof Dependencies)[]>
+/**
+  * A small wrapper to provide type inference.
+  * Create a Presence module which **MUST** be put in a file called presence.<file-ending> 
+  * adjacent to the file where **Sern.init** is CALLED.
+  */
+export function module<T extends (keyof Dependencies)[]>
 (conf: Config<T>) {
     return conf;
 }
 
-export type Result =
-    | {
-        repeated: { 
-            create: | number 
-                    | [Emitter, string];
-            onInterval: (previous: Result) => Once 
-        }
-      }
-    | Once;
+type PresenceReduce = (previous: Result) => Result;
+
+/**
+  * Create a Presence body which can be either: 
+  * - once, the presence is activated only once.
+  * - repeated, per cycle or event, the presence can be changed.
+  */
+export function of(root: Omit<Result, 'repeat' | 'onRepeat'>) {
+    return { 
+        /**
+         * @example
+         * Presence
+         *     .of({ 
+         *          activities: [{ name: "deez nuts" }] 
+         *     }) //starts the presence with "deez nuts".
+         *     .repeated(prev => { 
+         *         return {
+         *             afk: true,
+         *             activities: prev.activities?.map(s => ({ ...s, name: s.name+"s" }))
+         *         };
+         *     }, 10000)) //every 10 s, the callback sets the presence to the returned one.
+         */
+        repeated: (onRepeat: PresenceReduce, repeat: number | [Emitter, string]) => {
+            return { repeat, onRepeat, ...root }
+        },
+        /**
+         * @example
+         * Presence
+         *     .of({
+         *        activities: [
+         *          { name: "Chilling out" }
+         *        ]
+         *      })
+         *     .once() // Sets the presence once, with what's provided in '.of()'
+         */
+        once: () => root
+    };
+}
+

--- a/src/core/presences.ts
+++ b/src/core/presences.ts
@@ -1,5 +1,6 @@
-import { ActivitiesOptions } from "discord.js";
-import { IntoDependencies } from "../types/ioc";
+import type { ActivitiesOptions } from "discord.js";
+import type { IntoDependencies } from "../types/ioc";
+import type { Emitter } from "./contracts/emitter";
 
 type Status = 'online' | 'idle' | 'invisible' | 'dnd'
 
@@ -24,7 +25,8 @@ export function create<T extends (keyof Dependencies)[]>
 export type Result =
     | {
         repeated: { 
-            create: | number //interval
+            create: | number 
+                    | [Emitter, string];
             onInterval: (previous: Result) => Once 
         }
       }

--- a/src/core/presences.ts
+++ b/src/core/presences.ts
@@ -1,0 +1,31 @@
+import { ActivitiesOptions } from "discord.js";
+import { IntoDependencies } from "../types/ioc";
+
+type Status = 'online' | 'idle' | 'invisible' | 'dnd'
+
+interface Once { 
+    status?: Status;
+    afk?: boolean;
+    activities?: ActivitiesOptions[];
+    shardId?: number[];
+}
+
+export type Config <T extends (keyof Dependencies)[]> = 
+{
+    inject?: [...T]
+    execute: (...v: IntoDependencies<T>) => Result;
+};
+
+export function create<T extends (keyof Dependencies)[]>
+(conf: Config<T>) {
+    return conf;
+}
+
+export type Result =
+    | {
+        repeated: { 
+            create: | number //interval
+            onInterval: (previous: Result) => Once 
+        }
+      }
+    | Once;

--- a/src/core/presences.ts
+++ b/src/core/presences.ts
@@ -3,6 +3,7 @@ import type { IntoDependencies } from "../types/ioc";
 import type { Emitter } from "./contracts/emitter";
 
 type Status = 'online' | 'idle' | 'invisible' | 'dnd'
+type PresenceReduce = (previous: Result) => Result;
 
 export interface Result { 
     status?: Status;
@@ -21,7 +22,7 @@ export type Config <T extends (keyof Dependencies)[]> =
 
 /**
   * A small wrapper to provide type inference.
-  * Create a Presence module which **MUST** be put in a file called presence.<file-ending> 
+  * Create a Presence module which **MUST** be put in a file called presence.<language-extension> 
   * adjacent to the file where **Sern.init** is CALLED.
   */
 export function module<T extends (keyof Dependencies)[]>
@@ -29,7 +30,6 @@ export function module<T extends (keyof Dependencies)[]>
     return conf;
 }
 
-type PresenceReduce = (previous: Result) => Result;
 
 /**
   * Create a Presence body which can be either: 

--- a/src/handlers/presence.ts
+++ b/src/handlers/presence.ts
@@ -1,0 +1,36 @@
+import { concatMap, from, interval, of, map, scan, startWith } from "rxjs"
+import { Files } from "../core/_internal";
+import * as Presence from "../core/presences";
+import { Services } from "../core/ioc";
+
+type SetPresence = (conf: Presence.Result) => Promise<unknown>
+
+const parseConfig = async (conf: Promise<Presence.Result>) => {
+    return conf
+        .then(s => {
+            if('repeated' in s) {
+                const { create, onInterval } = s.repeated;
+                return interval(create).pipe(
+                    scan(onInterval, s),
+                    startWith(s));
+            }
+            //take 1?
+            return of(s);
+        })
+};
+
+export const presenceHandler = (path: string, setPresence: SetPresence) => {
+    interface PresenceModule  {
+        module: Presence.Config<(keyof Dependencies)[]>
+    }
+    const presence = Files
+        .importModule<PresenceModule>(path)
+        .then(({ module }) => {
+            const fetchedServices = Services(...module.inject ?? []);
+            return async () => module.execute(...fetchedServices);
+        })
+    const module$ = from(presence);
+    return module$.pipe(
+        concatMap(fn => parseConfig(fn())),
+        concatMap(conf => conf.pipe(map(setPresence))))
+}

--- a/src/handlers/presence.ts
+++ b/src/handlers/presence.ts
@@ -1,4 +1,4 @@
-import { concatMap, from, interval, of, map, scan, startWith, fromEvent } from "rxjs"
+import { concatMap, from, interval, of, map, scan, startWith, fromEvent, take } from "rxjs"
 import { Files } from "../core/_internal";
 import * as Presence from "../core/presences";
 import { Services } from "../core/ioc";
@@ -7,22 +7,21 @@ import assert from "node:assert";
 type SetPresence = (conf: Presence.Result) => Promise<unknown>
 
 const parseConfig = async (conf: Promise<Presence.Result>) => {
-    return conf
-        .then(s => {
-            if('repeat' in s) {
-                const { onRepeat, repeat } = s;
-                assert(repeat !== undefined, "repeat is undefined");
-                assert(onRepeat !== undefined, "onRepeat callback is undefined, but repeat exists");
-                const src$ = typeof repeat === 'number' 
-                    ? interval(repeat)
-                    : fromEvent(...repeat);
-                    return src$
-                        .pipe(scan(onRepeat, s), 
-                              startWith(s));
-                }
-            //take 1?
-            return of(s);
-        })
+    return conf.then(s => {
+        if('repeat' in s) {
+            const { onRepeat, repeat } = s;
+            assert(repeat !== undefined, "repeat option is undefined");
+            assert(onRepeat !== undefined, "onRepeat callback is undefined, but repeat exists");
+            const src$ = typeof repeat === 'number' 
+                ? interval(repeat)
+                : fromEvent(...repeat);
+                return src$
+                    .pipe(scan(onRepeat, s), 
+                          startWith(s));
+        }
+        //take 1?
+        return of(s).pipe(take(1));
+    })
 };
 
 export const presenceHandler = (path: string, setPresence: SetPresence) => {
@@ -32,11 +31,16 @@ export const presenceHandler = (path: string, setPresence: SetPresence) => {
     const presence = Files
         .importModule<PresenceModule>(path)
         .then(({ module }) => {
+            //fetch services with the order preserved, passing it to the execute fn 
             const fetchedServices = Services(...module.inject ?? []);
             return async () => module.execute(...fetchedServices);
         })
     const module$ = from(presence);
     return module$.pipe(
+        //compose:.
+        //call the execute function, passing that result into parseConfig.
+        //concatMap resolves the promise, and passes it to the next concatMap.
         concatMap(fn => parseConfig(fn())),
+        // subscribe to the observable parseConfig yields, and set the presence.
         concatMap(conf => conf.pipe(map(setPresence))))
 }

--- a/src/handlers/presence.ts
+++ b/src/handlers/presence.ts
@@ -2,19 +2,22 @@ import { concatMap, from, interval, of, map, scan, startWith, fromEvent } from "
 import { Files } from "../core/_internal";
 import * as Presence from "../core/presences";
 import { Services } from "../core/ioc";
+import assert from "node:assert";
 
 type SetPresence = (conf: Presence.Result) => Promise<unknown>
 
 const parseConfig = async (conf: Promise<Presence.Result>) => {
     return conf
         .then(s => {
-            if('repeated' in s) {
-                const { create, onInterval } = s.repeated;
-                const src$ = typeof create === 'number' 
-                    ? interval(create)
-                    : fromEvent(...create);
+            if('repeat' in s) {
+                const { onRepeat, repeat } = s;
+                assert(repeat !== undefined, "repeat is undefined");
+                assert(onRepeat !== undefined, "onRepeat callback is undefined, but repeat exists");
+                const src$ = typeof repeat === 'number' 
+                    ? interval(repeat)
+                    : fromEvent(...repeat);
                     return src$
-                        .pipe(scan(onInterval, s), 
+                        .pipe(scan(onRepeat, s), 
                               startWith(s));
                 }
             //take 1?

--- a/src/handlers/presence.ts
+++ b/src/handlers/presence.ts
@@ -1,4 +1,4 @@
-import { concatMap, from, interval, of, map, scan, startWith } from "rxjs"
+import { concatMap, from, interval, of, map, scan, startWith, fromEvent } from "rxjs"
 import { Files } from "../core/_internal";
 import * as Presence from "../core/presences";
 import { Services } from "../core/ioc";
@@ -10,10 +10,13 @@ const parseConfig = async (conf: Promise<Presence.Result>) => {
         .then(s => {
             if('repeated' in s) {
                 const { create, onInterval } = s.repeated;
-                return interval(create).pipe(
-                    scan(onInterval, s),
-                    startWith(s));
-            }
+                const src$ = typeof create === 'number' 
+                    ? interval(create)
+                    : fromEvent(...create);
+                    return src$
+                        .pipe(scan(onInterval, s), 
+                              startWith(s));
+                }
             //take 1?
             return of(s);
         })

--- a/src/handlers/ready-event.ts
+++ b/src/handlers/ready-event.ts
@@ -25,8 +25,7 @@ export function startReadyEvent(
 
 const once = () => pipe(
     first(),
-    ignoreElements()
-)
+    ignoreElements())
 
 
 function register<T extends Processed<AnyModule>>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export {
     CommandExecutable,
 } from './core/modules';
 
+export * as Presence from './core/presences'
+
 export {
     useContainerRaw
 } from './core/_internal'

--- a/src/sern.ts
+++ b/src/sern.ts
@@ -42,7 +42,6 @@ export function init(maybeWrapper: Wrapper | 'file') {
             const time = ((performance.now() - startTime) / 1000).toFixed(2);
             dependencies[0].emit('modulesLoaded');
             logger?.info({ message: `sern: registered all modules in ${time} s`, });
-            console.log(presencePath.exists)
             if(presencePath.exists) {
                 const setPresence = async (p: any) => {
                     return (dependencies[4] as Client).user?.setPresence(p);

--- a/test/core/presence.test.ts
+++ b/test/core/presence.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Presence } from '../../src';
+
+
+// Example test suite for the module function
+describe('module function', () => {
+  it('should return a valid configuration', () => {
+    const config: Presence.Config<['dependency1', 'dependency2']> = Presence.module({
+      inject: ['dependency1', 'dependency2'],
+      execute: vi.fn(),
+    });
+
+    expect(config).toBeDefined();
+    expect(config.inject).toEqual(['dependency1', 'dependency2']);
+    expect(typeof config.execute).toBe('function');
+  });
+});
+
+
+describe('of function', () => {
+  it('should return a valid presence configuration without repeat and onRepeat', () => {
+    const presenceConfig = Presence.of({
+      status: 'online',
+      afk: false,
+      activities: [{ name: 'Test Activity' }],
+      shardId: [1, 2, 3],
+    }).once();
+
+    expect(presenceConfig).toBeDefined();
+    //@ts-ignore Maybe fix?
+    expect(presenceConfig.repeat).toBeUndefined();
+    //@ts-ignore Maybe fix?
+    expect(presenceConfig.onRepeat).toBeUndefined();
+    expect(presenceConfig).toMatchObject({
+      status: 'online',
+      afk: false,
+      activities: [{ name: 'Test Activity' }],
+      shardId: [1, 2, 3],
+    });
+  });
+
+  it('should return a valid presence configuration with repeat and onRepeat', () => {
+    const onRepeatCallback = vi.fn();
+    const presenceConfig = Presence.of({
+      status: 'idle',
+      activities: [{ name: 'Another Test Activity' }],
+    }).repeated(onRepeatCallback, 5000);
+
+    expect(presenceConfig).toBeDefined();
+    expect(presenceConfig.repeat).toBe(5000);
+    expect(presenceConfig.onRepeat).toBe(onRepeatCallback);
+    expect(presenceConfig).toMatchObject({
+      status: 'idle',
+      activities: [{ name: 'Another Test Activity' }],
+    });
+  });
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,7 @@ __metadata:
     "@types/node": ^18.15.11
     "@typescript-eslint/eslint-plugin": 5.58.0
     "@typescript-eslint/parser": 5.59.1
+    callsites: ^3.1.0
     discord.js: ^14.11.0
     esbuild: ^0.17.0
     eslint: 8.39.0
@@ -1186,7 +1187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0":
+"callsites@npm:^3.0.0, callsites@npm:^3.1.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3


### PR DESCRIPTION

Declare a presence for sern to handle! The api is super simple.
Ensure you have a file called presence.(file-ending) ADJACENT to wherever Sern.init is called!
An example is here:
![ảnh](https://github.com/sern-handler/handler/assets/76754747/380612e3-d84a-4714-821b-89319a6dc0ab)
Sern.init is called in index.ts. 
I make a file presence.ts next to it with this:
```ts
import { Presence } from '@sern/handler'

export default Presence.module({ 
    inject: ['@sern/client'],
    execute: (c) => {
        return Presence
            .of({ activities: [ { name: "deez nuts" } ] })
            .repeated(prev => { 
                return {
                    afk: true,
                    activities: prev.activities?.map(s => ({ ...s, name: s.name+"s" }))
                };
            }, 10000);
    }
})
```
The example demonstrates a repeating presence, where every 10 seconds, we re set the presence.