### PR TITLE
fix: change `@param wrapper` -> `@param maybeWrapper` for `Sern.init`

### DIFF
--- a/src/sern.ts
+++ b/src/sern.ts
@@ -13,7 +13,7 @@ import { Client } from 'discord.js';
 
 /**
  * @since 1.0.0
- * @param wrapper Options to pass into sern.
+ * @param maybeWrapper Options to pass into sern.
  * Function to start the handler up
  * @example
  * ```ts title="src/index.ts"


### PR DESCRIPTION
Noticed this while using typedoc:
<img width="869" alt="image" src="https://github.com/sern-handler/handler/assets/47304910/ec7938a1-126c-4e91-8960-d04ed4144147">

After testing this change, the markdown file generated has the information about the parameter:
<img width="538" alt="image" src="https://github.com/sern-handler/handler/assets/47304910/0d073d38-f860-4474-9047-06864f702519">
