### PR TITLE
fix: fix eventModule typing for Discord events

### DIFF
--- a/src/core/modules.ts
+++ b/src/core/modules.ts
@@ -26,7 +26,7 @@ export function commandModule(mod: InputCommand): Module {
  * The wrapper function to define event modules for sern
  * @param mod
  */
-export function eventModule(mod: InputEvent): Module {
+export function eventModule<T extends keyof ClientEvents = keyof ClientEvents>(mod: InputEvent<T>): Module {
     const [onEvent, plugins] = partitionPlugins(mod.plugins);
     if(onEvent.length !== 0) throw Error("Event modules cannot have ControlPlugins");
     return { ...mod,
@@ -35,8 +35,9 @@ export function eventModule(mod: InputEvent): Module {
 }
 
 /** Create event modules from discord.js client events,
- * This is an {@link eventModule} for discord events,
- * where typings can be very bad.
+ * This was an {@link eventModule} for discord events,
+ * where typings were bad.
+ * @deprecated Use {@link eventModule} instead
  * @param mod
  */
 export function discordEvent<T extends keyof ClientEvents>(mod: {

--- a/src/types/core-modules.ts
+++ b/src/types/core-modules.ts
@@ -167,9 +167,9 @@ export interface CommandModuleDefs {
     [CommandType.Modal]: ModalSubmitCommand;
 }
 
-export interface EventModuleDefs {
+export interface EventModuleDefs<T extends keyof ClientEvents = keyof ClientEvents> {
     [EventType.Sern]: SernEventCommand;
-    [EventType.Discord]: DiscordEventCommand;
+    [EventType.Discord]: DiscordEventCommand<T>;
     [EventType.External]: ExternalEventCommand;
 }
 
@@ -186,12 +186,12 @@ export interface SernAutocompleteData
 type CommandModuleNoPlugins = {
     [T in CommandType]: Omit<CommandModuleDefs[T], 'plugins' | 'onEvent' | 'meta' | 'locals'>;
 };
-type EventModulesNoPlugins = {
-    [T in EventType]: Omit<EventModuleDefs[T], 'plugins' | 'onEvent' | 'meta' | 'locals'> ;
+type EventModulesNoPlugins<K extends keyof ClientEvents = keyof ClientEvents> = {
+    [T in EventType]: Omit<EventModuleDefs<K>[T], 'plugins' | 'onEvent' | 'meta' | 'locals'> ;
 };
 
-export type InputEvent = {
-    [T in EventType]: EventModulesNoPlugins[T] & {
+export type InputEvent<K extends keyof ClientEvents = keyof ClientEvents> = {
+    [T in EventType]: EventModulesNoPlugins<K>[T] & {
         once?: boolean;
         plugins?: InitPlugin[] 
     };


### PR DESCRIPTION
```js
import { eventModule, EventType } from "@sern/handler";
import type { GuildMember } from "discord.js";

export default eventModule({
    type: EventType.Discord,
    name: "guildMemberAdd",
    async execute(member) {
      //          ^ this is now inferred properly 🔥
    },
});
```