### PR TITLE
feat: moduleinfo-in-eventplugins

### DIFF
--- a/src/core/modules.ts
+++ b/src/core/modules.ts
@@ -10,8 +10,39 @@ import { partitionPlugins } from './functions'
 import type { Awaitable } from '../types/utility';
 
 /**
- * @since 1.0.0 The wrapper function to define command modules for sern
- * @param mod
+ * Creates a command module with standardized structure and plugin support.
+ * 
+ * @since 1.0.0
+ * @param {InputCommand} mod - Command module configuration
+ * @returns {Module} Processed command module ready for registration
+ * 
+ * @example
+ * // Basic slash command
+ * export default commandModule({
+ *   type: CommandType.Slash,
+ *   description: "Ping command",
+ *   execute: async (ctx) => {
+ *     await ctx.reply("Pong! 🏓");
+ *   }
+ * });
+ * 
+ * @example
+ * // Command with component interaction
+ * export default commandModule({
+ *   type: CommandType.Slash,
+ *   description: "Interactive command",
+ *   execute: async (ctx) => {
+ *     const button = new ButtonBuilder({
+ *       customId: "btn/someData",
+ *       label: "Click me",
+ *       style: ButtonStyle.Primary
+ *     });
+ *     await ctx.reply({
+ *       content: "Interactive message",
+ *       components: [new ActionRowBuilder().addComponents(button)]
+ *     });
+ *   }
+ * });
  */
 export function commandModule(mod: InputCommand): Module {
     const [onEvent, plugins] = partitionPlugins(mod.plugins);
@@ -21,10 +52,33 @@ export function commandModule(mod: InputCommand): Module {
              locals: {} } as Module;
 }
 
+
 /**
+ * Creates an event module for handling Discord.js or custom events.
+ * 
  * @since 1.0.0
- * The wrapper function to define event modules for sern
- * @param mod
+ * @template T - Event name from ClientEvents
+ * @param {InputEvent<T>} mod - Event module configuration
+ * @returns {Module} Processed event module ready for registration
+ * @throws {Error} If ControlPlugins are used in event modules
+ * 
+ * @example
+ * // Discord event listener
+ * export default eventModule({
+ *   type: EventType.Discord,
+ *   execute: async (message) => {
+ *     console.log(`${message.author.tag}: ${message.content}`);
+ *   }
+ * });
+ * 
+ * @example
+ * // Custom sern event
+ * export default eventModule({
+ *   type: EventType.Sern,
+ *   execute: async (eventData) => {
+ *     // Handle sern-specific event
+ *   }
+ * });
  */
 export function eventModule<T extends keyof ClientEvents = keyof ClientEvents>(mod: InputEvent<T>): Module {
     const [onEvent, plugins] = partitionPlugins(mod.plugins);

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -1,6 +1,7 @@
 import { CommandType, PluginType } from './structures/enums';
 import type { Plugin, PluginResult, CommandArgs, InitArgs } from '../types/core-plugin';
 import { Err, Ok } from './structures/result';
+import type { Dictionary } from '../types/utility';
 
 export function makePlugin<V extends unknown[]>(
     type: PluginType,
@@ -37,7 +38,7 @@ export function CommandControlPlugin<I extends CommandType>(
  * The object passed into every plugin to control a command's behavior
  */
 export const controller = {
-    next: (val?: Record<string,unknown>) => Ok(val),
+    next: (val?: Dictionary) => Ok(val),
     stop: (val?: string) => Err(val),
 };
 

--- a/src/handlers/event-utils.ts
+++ b/src/handlers/event-utils.ts
@@ -241,7 +241,19 @@ export async function callInitPlugins(_module: Module, deps: Dependencies, emit?
 export async function callPlugins({ args, module, deps, params }: ExecutePayload) {
     let state = {};
     for(const plugin of module.onEvent??[]) {
-        const result = await plugin.execute(...args, { state, deps, params, type: module.type });
+        const executionContext  = {
+            state, 
+            deps,
+            params,
+            type: module.type,
+            module: {
+                name: module.name,
+                description: module.description,
+                locals: module.locals,
+                meta: module.meta
+            }
+        };
+        const result = await plugin.execute(...args, executionContext);
         if(!result.ok) {
             return result;
         }

--- a/src/handlers/event-utils.ts
+++ b/src/handlers/event-utils.ts
@@ -246,12 +246,10 @@ export async function callPlugins({ args, module, deps, params }: ExecutePayload
             deps,
             params,
             type: module.type,
-            module: {
-                name: module.name,
-                description: module.description,
-                locals: module.locals,
-                meta: module.meta
-            }
+            module: { name: module.name,
+                      description: module.description,
+                      locals: module.locals,
+                      meta: module.meta }
         };
         const result = await plugin.execute(...args, executionContext);
         if(!result.ok) {
@@ -265,14 +263,26 @@ export async function callPlugins({ args, module, deps, params }: ExecutePayload
 }
 /**
  * Creates an executable task ( execute the command ) if all control plugins are successful
+ * this needs to go
  * @param onStop emits a failure response to the SernEmitter
  */
 export function intoTask(onStop: (m: Module) => unknown) {
-    const onNext = ({ args, module, deps, params }: ExecutePayload, state: Record<string, unknown>) => ({
-        module,
-        args: [...args, { state, deps, params, type: module.type }],
-        deps
-    });
+    const onNext = ({ args, module, deps, params }: ExecutePayload, state: Record<string, unknown>) => {
+        
+        return {
+            module,
+            args: [...args, { state,
+                              deps,
+                              params,
+                              type: module.type,
+                              module: { name: module.name,
+                                        description: module.description,
+                                        locals: module.locals,
+                                        meta: module.meta } }],
+            deps
+        }
+
+    };
     return createResultResolver({ onStop, onNext });
 }
 

--- a/src/handlers/presence.ts
+++ b/src/handlers/presence.ts
@@ -1,4 +1,4 @@
-import { concatMap, from, interval, of, map, scan, startWith, fromEvent, take, mergeScan } from "rxjs"
+import { concatMap, from, interval, of, map, startWith, fromEvent, take, mergeScan } from "rxjs"
 import { Presence  } from "../core/presences";
 import { Services } from "../core/ioc";
 import assert from "node:assert";

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -3,6 +3,7 @@ import type { Module } from './core-modules';
 import type { Result } from '../core/structures/result';
 
 export type Awaitable<T> = PromiseLike<T> | T;
+export type Dictionary = Record<string, unknown>
 
 export type VoidResult = Result<void, void>;
 export type AnyFunction = (...args: any[]) => unknown;


### PR DESCRIPTION
- docs
- pluigins have access to the module its being run in 

```ts
import { CommandControlPlugin, CommandType, controller } from "@sern/handler";


export default CommandControlPlugin((s, sdt)=> { 
    console.log(sdt.module.meta); 
    return controller.next() 
})
```

 yields:
 ```ts

{
   module: {
    name: 'ping',
    description: 'A ping command',
    locals: {},
    meta: {
      id: 'ping_B',
      absPath: 'file:///~'
    }
  }
}
{
  id: 'ping_B',
  absPath: 'file:///~'
}

 ```