### PR TITLE
feat: 4.2.0 load multiple directories & `handleModuleErrors`

### DIFF
--- a/src/handlers/ready.ts
+++ b/src/handlers/ready.ts
@@ -3,10 +3,10 @@ import { once } from 'node:events';
 import { resultPayload } from '../core/functions';
 import { CommandType } from '../core/structures/enums';
 import { Module } from '../types/core-modules';
-import type { UnpackedDependencies } from '../types/utility';
+import type { UnpackedDependencies, Wrapper } from '../types/utility';
 import { callInitPlugins } from './event-utils';
 
-export default async function(dir: string, deps : UnpackedDependencies) {
+export default async function(dirs: string | string[], deps : UnpackedDependencies) {
     const { '@sern/client': client,
             '@sern/logger': log,
             '@sern/emitter': sEmitter,
@@ -17,16 +17,21 @@ export default async function(dir: string, deps : UnpackedDependencies) {
 
     // https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator
     // possibly optimize to concurrently import modules
-    for await (const path of Files.readRecursive(dir)) {
-        let { module } = await Files.importModule<Module>(path);
-        const validType = module.type >= CommandType.Text && module.type <= CommandType.ChannelSelect;
-        if(!validType) {
-            throw Error(`Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``);
+
+    const directories = Array.isArray(dirs) ? dirs : [dirs];
+
+    for (const dir of directories) {
+        for await (const path of Files.readRecursive(dir)) {
+            let { module } = await Files.importModule<Module>(path);
+            const validType = module.type >= CommandType.Text && module.type <= CommandType.ChannelSelect;
+            if(!validType) {
+                throw Error(`Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``);
+            }
+            const resultModule = await callInitPlugins(module, deps, true);
+            // FREEZE! no more writing!!
+            commands.set(resultModule.meta.id, Object.freeze(resultModule));
+            sEmitter.emit('module.register', resultPayload('success', resultModule));
         }
-        const resultModule = await callInitPlugins(module, deps, true);
-        // FREEZE! no more writing!!
-        commands.set(resultModule.meta.id, Object.freeze(resultModule));
-        sEmitter.emit('module.register', resultPayload('success', resultModule));
     }
     sEmitter.emit('modulesLoaded');
 }

--- a/src/handlers/tasks.ts
+++ b/src/handlers/tasks.ts
@@ -1,16 +1,21 @@
 import * as Files from '../core/module-loading'
-import { UnpackedDependencies } from "../types/utility";
+import { UnpackedDependencies, Wrapper } from "../types/utility";
 import type { ScheduledTask } from "../types/core-modules";
 import { relative } from "path";
 import { fileURLToPath } from "url";
 
-export const registerTasks = async (tasksPath: string, deps: UnpackedDependencies) => {
+export const registerTasks = async (tasksDirs: string | string[], deps: UnpackedDependencies) => {
     const taskManager = deps['@sern/scheduler']
-    for await (const f of Files.readRecursive(tasksPath)) {
-        let { module } = await Files.importModule<ScheduledTask>(f);
-        //module.name is assigned by Files.importModule<>
-        // the id created for the task is unique
-        const uuid = module.name+"/"+relative(tasksPath,fileURLToPath(f))
-        taskManager.schedule(uuid, module, deps)
+
+    const directories = Array.isArray(tasksDirs) ? tasksDirs : [tasksDirs];
+
+    for (const dir of directories) {
+        for await (const path of Files.readRecursive(dir)) {
+            let { module } = await Files.importModule<ScheduledTask>(path);
+            //module.name is assigned by Files.importModule<>
+            // the id created for the task is unique
+            const uuid = module.name+"/"+relative(dir,fileURLToPath(path))
+            taskManager.schedule(uuid, module, deps)
+        }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,20 +53,3 @@ export * from './core/plugin';
 export { CommandType, PluginType, PayloadType, EventType } from './core/structures/enums';
 export { Context } from './core/structures/context';
 export { type CoreDependencies, makeDependencies, single, transient, Service, Services } from './core/ioc';
-
-
-import type { Container } from '@sern/ioc';
-
-/**
-  * @deprecated This old signature will be incompatible with future versions of sern >= 4.0.0. See {@link makeDependencies}
-  * @example
-  * ```ts
-  *  To switch your old code:
-     await makeDependencies(({ add }) => { 
-            add('@sern/client', new Client())
-     })
-  *  ```
-  */
-export interface DependencyConfiguration {
-    build: (root: Container) => Container;
-}

--- a/src/sern.ts
+++ b/src/sern.ts
@@ -45,9 +45,9 @@ export function init(maybeWrapper: Wrapper = { commands: "./dist/commands" }) {
     // convenient for rapid iteration
     if(maybeWrapper.handleModuleErrors) {
         if(!deps['@sern/logger']) {
-            throw Error('A logger is required to autoHandleModuleErrors.\n A default logger is already supplied!');
+            throw Error('A logger is required to handleModuleErrors.\n A default logger is already supplied!');
         }
-        deps['@sern/logger']?.info({ 'message': 'autoHandleModuleErrors enabled' })
+        deps['@sern/logger']?.info({ 'message': 'handleModuleErrors enabled' })
         deps['@sern/emitter'].addListener('error', (payload: Payload) => {
             if(payload.type === 'failure') {
                 deps['@sern/logger']?.error({ message: payload.reason })

--- a/src/sern.ts
+++ b/src/sern.ts
@@ -43,7 +43,7 @@ export function init(maybeWrapper: Wrapper = { commands: "./dist/commands" }) {
 
     // autohandle errors that occur in modules.
     // convenient for rapid iteration
-    if(maybeWrapper.autoHandleErrors) {
+    if(maybeWrapper.handleModuleErrors) {
         if(!deps['@sern/logger']) {
             throw Error('A logger is required to autoHandleModuleErrors.\n A default logger is already supplied!');
         }

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -26,9 +26,64 @@ export type UnpackedDependencies = {
 export type ReplyOptions = string | Omit<InteractionReplyOptions, 'fetchReply'> | MessageReplyOptions;
 
 
+/**
+ * @interface Wrapper
+ * @description Configuration interface for the sern framework. This interface defines
+ * the structure for configuring essential framework features including command handling,
+ * event management, and task scheduling.
+ */
 export interface Wrapper {
+    /**
+     * @property {string} commands
+     * @description Specifies the directory path where command modules are located.
+     * This is a required property that tells Sern where to find and load command files.
+     * The path should be relative to the project root.
+     * 
+     * @example
+     * commands: "./dist/commands"
+     */
     commands: string;
+
+    /**
+     * @property {boolean} [autoHandleErrors]
+     * @description Optional flag to enable automatic error handling for modules.
+     * When enabled, sern will automatically catch and handle errors that occur
+     * during module execution, preventing crashes and providing error logging.
+     * 
+     * @default false
+     */
+    autoHandleErrors?: boolean;
+
+    /**
+     * @property {string} [defaultPrefix]
+     * @description Optional prefix for text commands. This prefix will be used
+     * to identify text commands in messages. If not specified, text commands {@link CommandType.Text}
+     * will be disabled.
+     * 
+     * @example
+     * defaultPrefix: "?"
+     */
     defaultPrefix?: string;
+
+    /**
+     * @property {string} [events]
+     * @description Optional directory path where event modules are located.
+     * If provided, Sern will automatically register and handle events from
+     * modules in this directory. The path should be relative to the project root.
+     * 
+     * @example
+     * events: "./dist/events"
+     */
     events?: string;
+
+    /**
+     * @property {string} [tasks]
+     * @description Optional directory path where scheduled task modules are located.
+     * If provided, Sern will automatically register and handle scheduled tasks
+     * from modules in this directory. The path should be relative to the project root.
+     * 
+     * @example
+     * tasks: "./dist/tasks"
+     */
     tasks?: string;
 }

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -34,16 +34,15 @@ export type ReplyOptions = string | Omit<InteractionReplyOptions, 'fetchReply'> 
  */
 export interface Wrapper {
     /**
-     * @property {string} commands
+     * @property {string|string[]} commands
      * @description Specifies the directory path where command modules are located.
      * This is a required property that tells Sern where to find and load command files.
      * The path should be relative to the project root.
      * 
      * @example
-     * commands: "./dist/commands"
+     * commands: ["./dist/commands"]
      */
-    commands: string;
-
+    commands: string | string[];
     /**
      * @property {boolean} [autoHandleErrors]
      * @description Optional flag to enable automatic error handling for modules.
@@ -53,7 +52,6 @@ export interface Wrapper {
      * @default false
      */
     autoHandleErrors?: boolean;
-
     /**
      * @property {string} [defaultPrefix]
      * @description Optional prefix for text commands. This prefix will be used
@@ -64,26 +62,24 @@ export interface Wrapper {
      * defaultPrefix: "?"
      */
     defaultPrefix?: string;
-
     /**
-     * @property {string} [events]
+     * @property {string|string[]} [events]
      * @description Optional directory path where event modules are located.
      * If provided, Sern will automatically register and handle events from
      * modules in this directory. The path should be relative to the project root.
      * 
      * @example
-     * events: "./dist/events"
+     * events: ["./dist/events"]
      */
-    events?: string;
-
+    events?: string | string[];
     /**
-     * @property {string} [tasks]
+     * @property {string|string[]} [tasks]
      * @description Optional directory path where scheduled task modules are located.
      * If provided, Sern will automatically register and handle scheduled tasks
      * from modules in this directory. The path should be relative to the project root.
      * 
      * @example
-     * tasks: "./dist/tasks"
+     * tasks: ["./dist/tasks"]
      */
-    tasks?: string;
+    tasks?: string | string[];
 }

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -44,14 +44,14 @@ export interface Wrapper {
      */
     commands: string | string[];
     /**
-     * @property {boolean} [autoHandleErrors]
+     * @property {boolean} [handleModuleErrors]
      * @description Optional flag to enable automatic error handling for modules.
      * When enabled, sern will automatically catch and handle errors that occur
      * during module execution, preventing crashes and providing error logging.
      * 
      * @default false
      */
-    autoHandleErrors?: boolean;
+    handleModuleErrors?: boolean;
     /**
      * @property {string} [defaultPrefix]
      * @description Optional prefix for text commands. This prefix will be used

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -36,9 +36,10 @@ export interface Wrapper {
     /**
      * @property {string|string[]} commands
      * @description Specifies the directory path where command modules are located.
-     * This is a required property that tells Sern where to find and load command files.
-     * The path should be relative to the project root.
-     * 
+     * This is a required property that tells sern where to find and load command files.
+     * The path should be relative to the project root. If given an array, each directory is loaded in order
+     * they were declared. Order of modules in each directory is not guaranteed
+     *
      * @example
      * commands: ["./dist/commands"]
      */
@@ -67,6 +68,8 @@ export interface Wrapper {
      * @description Optional directory path where event modules are located.
      * If provided, Sern will automatically register and handle events from
      * modules in this directory. The path should be relative to the project root.
+     * If given an array, each directory is loaded in order they were declared. 
+     * Order of modules in each directory is not guaranteed.
      * 
      * @example
      * events: ["./dist/events"]
@@ -77,6 +80,8 @@ export interface Wrapper {
      * @description Optional directory path where scheduled task modules are located.
      * If provided, Sern will automatically register and handle scheduled tasks
      * from modules in this directory. The path should be relative to the project root.
+     * If given an array, each directory is loaded in order they were declared. 
+     * Order of modules in each directory is not guaranteed.
      * 
      * @example
      * tasks: ["./dist/tasks"]


### PR DESCRIPTION
wrapper can `handleModuleErrors` and accepts arrays as paths

feat: array based module loading

Co-authored-by: Duro <davidwright13503@gmail.com>
See-also: #379 