### PR TITLE
feat: array based module loading

### DIFF
--- a/src/handlers/ready.ts
+++ b/src/handlers/ready.ts
@@ -3,10 +3,10 @@ import { once } from 'node:events';
 import { resultPayload } from '../core/functions';
 import { CommandType } from '../core/structures/enums';
 import { Module } from '../types/core-modules';
-import type { UnpackedDependencies } from '../types/utility';
+import type { UnpackedDependencies, Wrapper } from '../types/utility';
 import { callInitPlugins } from './event-utils';
 
-export default async function(dir: string, deps : UnpackedDependencies) {
+export default async function(dirs: string | string[], deps : UnpackedDependencies) {
     const { '@sern/client': client,
             '@sern/logger': log,
             '@sern/emitter': sEmitter,
@@ -17,16 +17,21 @@ export default async function(dir: string, deps : UnpackedDependencies) {
 
     // https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator
     // possibly optimize to concurrently import modules
-    for await (const path of Files.readRecursive(dir)) {
-        let { module } = await Files.importModule<Module>(path);
-        const validType = module.type >= CommandType.Text && module.type <= CommandType.ChannelSelect;
-        if(!validType) {
-            throw Error(`Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``);
+
+    const directories = Array.isArray(dirs) ? dirs : [dirs];
+
+    for (const dir of directories) {
+        for await (const path of Files.readRecursive(dir)) {
+            let { module } = await Files.importModule<Module>(path);
+            const validType = module.type >= CommandType.Text && module.type <= CommandType.ChannelSelect;
+            if(!validType) {
+                throw Error(`Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``);
+            }
+            const resultModule = await callInitPlugins(module, deps, true);
+            // FREEZE! no more writing!!
+            commands.set(resultModule.meta.id, Object.freeze(resultModule));
+            sEmitter.emit('module.register', resultPayload('success', resultModule));
         }
-        const resultModule = await callInitPlugins(module, deps, true);
-        // FREEZE! no more writing!!
-        commands.set(resultModule.meta.id, Object.freeze(resultModule));
-        sEmitter.emit('module.register', resultPayload('success', resultModule));
     }
     sEmitter.emit('modulesLoaded');
 }

--- a/src/handlers/tasks.ts
+++ b/src/handlers/tasks.ts
@@ -1,16 +1,21 @@
 import * as Files from '../core/module-loading'
-import { UnpackedDependencies } from "../types/utility";
+import { UnpackedDependencies, Wrapper } from "../types/utility";
 import type { ScheduledTask } from "../types/core-modules";
 import { relative } from "path";
 import { fileURLToPath } from "url";
 
-export const registerTasks = async (tasksPath: string, deps: UnpackedDependencies) => {
+export const registerTasks = async (tasksDirs: string | string[], deps: UnpackedDependencies) => {
     const taskManager = deps['@sern/scheduler']
-    for await (const f of Files.readRecursive(tasksPath)) {
-        let { module } = await Files.importModule<ScheduledTask>(f);
-        //module.name is assigned by Files.importModule<>
-        // the id created for the task is unique
-        const uuid = module.name+"/"+relative(tasksPath,fileURLToPath(f))
-        taskManager.schedule(uuid, module, deps)
+
+    const directories = Array.isArray(tasksDirs) ? tasksDirs : [tasksDirs];
+
+    for (const dir of directories) {
+        for await (const path of Files.readRecursive(dir)) {
+            let { module } = await Files.importModule<ScheduledTask>(path);
+            //module.name is assigned by Files.importModule<>
+            // the id created for the task is unique
+            const uuid = module.name+"/"+relative(dir,fileURLToPath(path))
+            taskManager.schedule(uuid, module, deps)
+        }
     }
 }

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -27,8 +27,8 @@ export type ReplyOptions = string | Omit<InteractionReplyOptions, 'fetchReply'> 
 
 
 export interface Wrapper {
-    commands: string;
+    commands: string | string[];
     defaultPrefix?: string;
-    events?: string;
-    tasks?: string;
+    events?: string | string[];
+    tasks?: string | string[];
 }


### PR DESCRIPTION
can now supply `events`, `tasks`, or `commands` with an array (strings still work)

ie:

```ts
Sern.init({
  commands: ['dist/commands', 'dist/more-commands'],
  events: 'dist/events',
});
``