### PR TITLE
fix: flat autocomplete

### DIFF
--- a/src/handlers/interaction.ts
+++ b/src/handlers/interaction.ts
@@ -33,8 +33,8 @@ export function interactionHandler(deps: UnpackedDependencies, defaultPrefix?: s
         // handles autocomplete
         if(isAutocomplete(event)) {
             const lookupTable = module.locals['@sern/lookup-table'] as Map<string, SernAutocompleteData>
-            const subCommandGroup = event.options.getSubcommandGroup() ?? "",
-                  subCommand = event.options.getSubcommand() ?? "",
+            const subCommandGroup = event.options.getSubcommandGroup(false) ?? "",
+                  subCommand = event.options.getSubcommand(false) ?? "",
                   option = event.options.getFocused(true),
                   fullPath = path.posix.join("<parent>", subCommandGroup, subCommand, option.name)
                   


### PR DESCRIPTION
- commands with no subcommands would crash. this was a regression introduced in 4.2.2