### PR TITLE
fix ready deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/node-cron": "^3.0.11",
                 "@typescript-eslint/eslint-plugin": "5.58.0",
                 "@typescript-eslint/parser": "5.59.1",
-                "discord.js": "^14.14.1",
+                "discord.js": "^14.22.1",
                 "eslint": "8.39.0",
                 "typescript": "5.0.2",
                 "vitest": "^1.6.0"
@@ -30,16 +30,16 @@
             }
         },
         "node_modules/@discordjs/builders": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.10.1.tgz",
-            "integrity": "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.3.tgz",
+            "integrity": "sha512-p3kf5eV49CJiRTfhtutUCeivSyQ/l2JlKodW1ZquRwwvlOWmG9+6jFShX6x8rUiYhnP6wKI96rgN/SXMy5e5aw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@discordjs/formatters": "^0.6.0",
+                "@discordjs/formatters": "^0.6.1",
                 "@discordjs/util": "^1.1.1",
                 "@sapphire/shapeshift": "^4.0.0",
-                "discord-api-types": "^0.37.119",
+                "discord-api-types": "^0.38.16",
                 "fast-deep-equal": "^3.1.3",
                 "ts-mixer": "^6.0.4",
                 "tslib": "^2.6.3"
@@ -62,13 +62,13 @@
             }
         },
         "node_modules/@discordjs/formatters": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0.tgz",
-            "integrity": "sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
+            "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "discord-api-types": "^0.37.114"
+                "discord-api-types": "^0.38.1"
             },
             "engines": {
                 "node": ">=16.11.0"
@@ -78,9 +78,9 @@
             }
         },
         "node_modules/@discordjs/rest": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.3.tgz",
-            "integrity": "sha512-+SO4RKvWsM+y8uFHgYQrcTl/3+cY02uQOH7/7bKbVZsTfrfpoE62o5p+mmV+s7FVhTX82/kQUGGbu4YlV60RtA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+            "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -89,10 +89,10 @@
                 "@sapphire/async-queue": "^1.5.3",
                 "@sapphire/snowflake": "^3.5.3",
                 "@vladfrangu/async_event_emitter": "^2.4.6",
-                "discord-api-types": "^0.37.119",
+                "discord-api-types": "^0.38.16",
                 "magic-bytes.js": "^1.10.0",
                 "tslib": "^2.6.3",
-                "undici": "6.21.1"
+                "undici": "6.21.3"
             },
             "engines": {
                 "node": ">=18"
@@ -128,19 +128,19 @@
             }
         },
         "node_modules/@discordjs/ws": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.1.tgz",
-            "integrity": "sha512-PBvenhZG56a6tMWF/f4P6f4GxZKJTBG95n7aiGSPTnodmz4N5g60t79rSIAq7ywMbv8A4jFtexMruH+oe51aQQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+            "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@discordjs/collection": "^2.1.0",
-                "@discordjs/rest": "^2.4.3",
+                "@discordjs/rest": "^2.5.1",
                 "@discordjs/util": "^1.1.0",
                 "@sapphire/async-queue": "^1.5.2",
                 "@types/ws": "^8.5.10",
                 "@vladfrangu/async_event_emitter": "^2.2.4",
-                "discord-api-types": "^0.37.119",
+                "discord-api-types": "^0.38.1",
                 "tslib": "^2.6.2",
                 "ws": "^8.17.0"
             },
@@ -1091,9 +1091,9 @@
             "license": "MIT"
         },
         "node_modules/@types/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1911,31 +1911,35 @@
             }
         },
         "node_modules/discord-api-types": {
-            "version": "0.37.119",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.119.tgz",
-            "integrity": "sha512-WasbGFXEB+VQWXlo6IpW3oUv73Yuau1Ig4AZF/m13tXcTKnMpc/mHjpztIlz4+BM9FG9BHQkEXiPto3bKduQUg==",
+            "version": "0.38.26",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.26.tgz",
+            "integrity": "sha512-xpmPviHjIJ6dFu1eNwNDIGQ3N6qmPUUYFVAx/YZ64h7ZgPkTcKjnciD8bZe8Vbeji7yS5uYljyciunpq0J5NSw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "workspaces": [
+                "scripts/actions/documentation"
+            ]
         },
         "node_modules/discord.js": {
-            "version": "14.18.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.18.0.tgz",
-            "integrity": "sha512-SvU5kVUvwunQhN2/+0t55QW/1EHfB1lp0TtLZUSXVHDmyHTrdOj5LRKdR0zLcybaA15F+NtdWuWmGOX9lE+CAw==",
+            "version": "14.22.1",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.22.1.tgz",
+            "integrity": "sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@discordjs/builders": "^1.10.1",
+                "@discordjs/builders": "^1.11.2",
                 "@discordjs/collection": "1.5.3",
-                "@discordjs/formatters": "^0.6.0",
-                "@discordjs/rest": "^2.4.3",
+                "@discordjs/formatters": "^0.6.1",
+                "@discordjs/rest": "^2.6.0",
                 "@discordjs/util": "^1.1.1",
-                "@discordjs/ws": "^1.2.1",
+                "@discordjs/ws": "^1.2.3",
                 "@sapphire/snowflake": "3.5.3",
-                "discord-api-types": "^0.37.119",
+                "discord-api-types": "^0.38.16",
                 "fast-deep-equal": "3.1.3",
                 "lodash.snakecase": "4.1.1",
+                "magic-bytes.js": "^1.10.0",
                 "tslib": "^2.6.3",
-                "undici": "6.21.1"
+                "undici": "6.21.3"
             },
             "engines": {
                 "node": ">=18"
@@ -2779,9 +2783,9 @@
             }
         },
         "node_modules/magic-bytes.js": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
-            "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+            "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==",
             "dev": true,
             "license": "MIT"
         },
@@ -3629,9 +3633,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "6.21.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-            "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+            "version": "6.21.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+            "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sern/handler",
     "packageManager": "yarn@3.5.0",
-    "version": "4.2.4",
+    "version": "4.2.5",
     "description": "A complete, customizable, typesafe, & reactive framework for discord bots.",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@types/node-cron": "^3.0.11",
         "@typescript-eslint/eslint-plugin": "5.58.0",
         "@typescript-eslint/parser": "5.59.1",
-        "discord.js": "^14.14.1",
+        "discord.js": "^14.22.1",
         "eslint": "8.39.0",
         "typescript": "5.0.2",
         "vitest": "^1.6.0"

--- a/src/handlers/ready.ts
+++ b/src/handlers/ready.ts
@@ -1,44 +1,58 @@
-import * as Files from '../core/module-loading'
-import { once } from 'node:events';
-import { createLookupTable, resultPayload } from '../core/functions';
-import { CommandType } from '../core/structures/enums';
-import { Module, SernOptionsData } from '../types/core-modules';
-import type { UnpackedDependencies, Wrapper } from '../types/utility';
-import { callInitPlugins } from './event-utils';
-import { SernAutocompleteData } from '..';
+import * as Files from "../core/module-loading";
+import { once } from "node:events";
+import { createLookupTable, resultPayload } from "../core/functions";
+import { CommandType } from "../core/structures/enums";
+import { Module, SernOptionsData } from "../types/core-modules";
+import type { UnpackedDependencies, Wrapper } from "../types/utility";
+import { callInitPlugins } from "./event-utils";
+import { SernAutocompleteData } from "..";
+import { Events } from "discord.js";
 
-export default async function(dirs: string | string[], deps : UnpackedDependencies) {
-    const { '@sern/client': client,
-            '@sern/logger': log,
-            '@sern/emitter': sEmitter,
-            '@sern/modules': commands } = deps;
-    log?.info({ message: "Waiting on discord client to be ready..." })
-    await once(client, "clientReady");
-    log?.info({ message: "Client signaled ready, registering modules" });
+export default async function (
+  dirs: string | string[],
+  deps: UnpackedDependencies,
+) {
+  const {
+    "@sern/client": client,
+    "@sern/logger": log,
+    "@sern/emitter": sEmitter,
+    "@sern/modules": commands,
+  } = deps;
+  log?.info({ message: "Waiting on discord client to be ready..." });
+  await once(client, Events.ClientReady);
+  log?.info({ message: "Client signaled ready, registering modules" });
 
-    // https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator
-    // possibly optimize to concurrently import modules
+  // https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator
+  // possibly optimize to concurrently import modules
 
-    const directories = Array.isArray(dirs) ? dirs : [dirs];
+  const directories = Array.isArray(dirs) ? dirs : [dirs];
 
-    for (const dir of directories) {
-        for await (const path of Files.readRecursive(dir)) {
-            let { module } = await Files.importModule<Module>(path);
-            const validType = module.type >= CommandType.Text && module.type <= CommandType.ChannelSelect;
-            if(!validType) {
-                throw Error(`Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``);
-            }
-            const resultModule = await callInitPlugins(module, deps, true);
+  for (const dir of directories) {
+    for await (const path of Files.readRecursive(dir)) {
+      const { module } = await Files.importModule<Module>(path);
+      const validType =
+        module.type >= CommandType.Text &&
+        module.type <= CommandType.ChannelSelect;
+      if (!validType) {
+        throw Error(
+          `Found ${module.name} at ${module.meta.absPath}, which has incorrect \`type\``,
+        );
+      }
+      const resultModule = await callInitPlugins(module, deps, true);
 
-            if(module.type === CommandType.Both || module.type === CommandType.Slash) {
-               const options  = (Reflect.get(module, 'options') ?? []) as SernOptionsData[];
-               const lookupTable = createLookupTable(options)
-               module.locals['@sern/lookup-table'] = lookupTable;
-            }
-            // FREEZE! no more writing!!
-            commands.set(resultModule.meta.id, Object.freeze(resultModule));
-            sEmitter.emit('module.register', resultPayload('success', resultModule));
-        }
+      if (
+        module.type === CommandType.Both ||
+        module.type === CommandType.Slash
+      ) {
+        const options = (Reflect.get(module, "options") ??
+          []) as SernOptionsData[];
+        const lookupTable = createLookupTable(options);
+        module.locals["@sern/lookup-table"] = lookupTable;
+      }
+      // FREEZE! no more writing!!
+      commands.set(resultModule.meta.id, Object.freeze(resultModule));
+      sEmitter.emit("module.register", resultPayload("success", resultModule));
     }
-    sEmitter.emit('modulesLoaded');
+  }
+  sEmitter.emit("modulesLoaded");
 }

--- a/src/handlers/ready.ts
+++ b/src/handlers/ready.ts
@@ -13,7 +13,7 @@ export default async function(dirs: string | string[], deps : UnpackedDependenci
             '@sern/emitter': sEmitter,
             '@sern/modules': commands } = deps;
     log?.info({ message: "Waiting on discord client to be ready..." })
-    await once(client, "ready");
+    await once(client, "clientReady");
     log?.info({ message: "Client signaled ready, registering modules" });
 
     // https://observablehq.com/@ehouais/multiple-promises-as-an-async-generator


### PR DESCRIPTION
fixes the deprecation warning

> [!warning]
> this also bumps discord.js to `^14.22.1`, but there shouldn't be any breaking changes.

```
DeprecationWarning: The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.
      at triggerClientReady (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketManager.js:389:15)
      at checkShardsReady (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketManager.js:368:10)
      at <anonymous> (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketManager.js:198:16)
      at emit2 (node:events:123:31)
      at checkReady (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketShard.js:184:12)
      at gotGuild (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketShard.js:158:10)
      at <anonymous> (/Users/david/Programming/TypeScript/2910-bot/node_modules/discord.js/src/client/websocket/WebSocketManager.js:238:15)
      at emit (/Users/david/Programming/TypeScript/2910-bot/node_modules/@vladfrangu/async_event_emitter/dist/index.cjs:287:31)
      at emit (/Users/david/Programming/TypeScript/2910-bot/node_modules/@vladfrangu/async_event_emitter/dist/index.cjs:287:31)

```